### PR TITLE
Fixed bug where grouping capabilities for video devices was causing v…

### DIFF
--- a/Sources/Video.DirectShow/VideoCapabilities.cs
+++ b/Sources/Video.DirectShow/VideoCapabilities.cs
@@ -77,24 +77,25 @@ namespace AForge.Video.DirectShow
                 throw new NotSupportedException( "Unable to retrieve video device capabilities. This video device requires a larger VideoStreamConfigCaps structure." );
 
             // group capabilities with similar parameters
-            Dictionary<uint, VideoCapabilities> videocapsList = new Dictionary<uint, VideoCapabilities>( );
+            Dictionary<ulong, VideoCapabilities> videocapsList = new Dictionary<ulong, VideoCapabilities>();
 
-            for ( int i = 0; i < count; i++ )
+            for (int i = 0; i < count; i++)
             {
                 try
                 {
-                    VideoCapabilities vc = new VideoCapabilities( videoStreamConfig, i );
+                    VideoCapabilities vc = new VideoCapabilities(videoStreamConfig, i);
 
-                    uint key = ( ( (uint) vc.FrameSize.Height ) << 32 ) |
-                               ( ( (uint) vc.FrameSize.Width ) << 16 );
+                    ulong key = (((uint)vc.AverageFrameRate) << 48) |
+                               (((uint)vc.FrameSize.Height) << 32) |
+                               (((uint)vc.FrameSize.Width) << 16);
 
-                    if ( !videocapsList.ContainsKey( key ) )
+                    if (!videocapsList.ContainsKey(key))
                     {
-                        videocapsList.Add( key, vc );
+                        videocapsList.Add(key, vc);
                     }
                     else
                     {
-                        if ( vc.BitCount > videocapsList[key].BitCount )
+                        if (vc.BitCount > videocapsList[key].BitCount)
                         {
                             videocapsList[key] = vc;
                         }
@@ -104,6 +105,7 @@ namespace AForge.Video.DirectShow
                 {
                 }
             }
+
 
             VideoCapabilities[] videocaps = new VideoCapabilities[videocapsList.Count];
             videocapsList.Values.CopyTo( videocaps, 0 );


### PR DESCRIPTION
…ideo capabilities with different frame rates to be ignored.