### PR TITLE
Updated AVIReader and AVIWriter to work on 64-bit systems.

### DIFF
--- a/Sources/Video.VFW/AVIReader.cs
+++ b/Sources/Video.VFW/AVIReader.cs
@@ -12,7 +12,7 @@ namespace AForge.Video.VFW
     using System.Drawing;
     using System.Drawing.Imaging;
     using System.Runtime.InteropServices;
-    using AForge;
+    using AForge.Video;
 
     /// <summary>
     /// AVI files reading using Video for Windows.
@@ -348,12 +348,16 @@ namespace AForge.Video.VFW
                 if ( bitmapInfoHeader.height > 0 )
                 {
                     // it`s a bottom-top image
-                    int dst = imageData.Scan0.ToInt32( ) + dstStride * ( height - 1 );
-                    int src = DIB.ToInt32( ) + Marshal.SizeOf( typeof( Win32.BITMAPINFOHEADER ) );
+                    int dst = dstStride * ( height - 1 );
+                    int src = Marshal.SizeOf( typeof( Win32.BITMAPINFOHEADER ) );
 
                     for ( int y = 0; y < height; y++ )
                     {
-                        Win32.memcpy( dst, src, srcStride );
+                        Win32.CopyMemory(
+									IntPtr.Add( imageData.Scan0, dst ),
+									IntPtr.Add( DIB, src ),
+									( uint )srcStride );
+
                         dst -= dstStride;
                         src += srcStride;
                     }
@@ -361,11 +365,13 @@ namespace AForge.Video.VFW
                 else
                 {
                     // it`s a top bootom image
-                    int dst = imageData.Scan0.ToInt32( );
-                    int src = DIB.ToInt32( ) + Marshal.SizeOf( typeof( Win32.BITMAPINFOHEADER ) );
+                    int src = Marshal.SizeOf( typeof( Win32.BITMAPINFOHEADER ) );
 
                     // copy the whole image
-                    Win32.memcpy( dst, src, srcStride * height );
+                    Win32.CopyMemory(
+							  imageData.Scan0,
+							  IntPtr.Add( DIB, src ),
+							  ( uint )( srcStride * height ) );
                 }
 
                 // unlock bitmap data

--- a/Sources/Video.VFW/AVIWriter.cs
+++ b/Sources/Video.VFW/AVIWriter.cs
@@ -402,12 +402,15 @@ namespace AForge.Video.VFW
                 int srcStride = imageData.Stride;
                 int dstStride = stride;
 
-                int src = imageData.Scan0.ToInt32( ) + srcStride * ( height - 1 );
-                int dst = buffer.ToInt32( );
+                int src = srcStride * ( height - 1 );
+                int dst = 0;
 
                 for ( int y = 0; y < height; y++ )
                 {
-                    Win32.memcpy( dst, src, dstStride );
+                    Win32.CopyMemory(
+							  IntPtr.Add( imageData.Scan0, dst ),
+							  IntPtr.Add( buffer, src ),
+							  ( uint )dstStride );
                     dst += dstStride;
                     src -= srcStride;
                 }

--- a/Sources/Video.VFW/Win32.cs
+++ b/Sources/Video.VFW/Win32.cs
@@ -23,18 +23,14 @@ namespace AForge.Video.VFW
         /// Copy a block of memory.
         /// </summary>
         /// 
-        /// <param name="dst">Destination pointer.</param>
+        /// <param name="dest">Destination pointer.</param>
         /// <param name="src">Source pointer.</param>
         /// <param name="count">Memory block's length to copy.</param>
         /// 
         /// <returns>Return's the value of <b>dst</b> - pointer to destination.</returns>
         /// 
-        [DllImport( "ntdll.dll", CallingConvention = CallingConvention.Cdecl )]
-        public static extern int memcpy(
-            int dst,
-            int src,
-            int count );
-
+        [DllImport("kernel32.dll", EntryPoint = "CopyMemory", SetLastError = false)]
+        public static extern void CopyMemory(IntPtr dest, IntPtr src, uint count);
 
         // --- Video for Windows Functions
 


### PR DESCRIPTION
In the AVIWriter.AddFrame and AVIReader.GetNextFrame methods, converting the IntPtr's to ints to do math and perform a memcpy caused an ArithmeticOverflowException on 64-bit systems. I modified it to perform the math and the copy directly with the IntPtr's and not throw exceptions.